### PR TITLE
fix to handle not existing and not authorized accounts.

### DIFF
--- a/libraries/twitterfetcher.php
+++ b/libraries/twitterfetcher.php
@@ -135,7 +135,7 @@ class twitterfetcher {
 				fclose($fh);
 			}	
 		}
-		else if (isset($tweets->error)) {
+		else if (isset($tweets->errors) || isset($tweets->error)) {
 			return false;
 		}
 		else {


### PR DESCRIPTION
fix to handle not existing and not authorized accounts.

    {
        request: "/1/statuses/user_timeline.json?screen_name=NotauthorizedAccount",
        error: "Not authorized"
    }

or

    {
        errors: [
            {
                message: "Sorry, that page does not exist",
                code: 34
            }
        ]
    }
