### PR TITLE
API upgrade required

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -25,23 +25,27 @@ Variables
 ---------
 
 - **twitterID** (no default, required): the twitter username/ID you wish to fetch tweets for
+- **ConsumerKey** (hash, required): Your twitter consumer key
+- **ConsumerSecret** (hash, required): Your twitter consumer secret
 - **count** (int, default = 1): number of tweets to fetch, setting this to 0 will fetch all tweets for the specified user
 - **format** (json/xml, default = json): specify the format of the data structure returned
 - **usecache** (true/false, default = true): whether or not to use a local cache file, which needs to be located at *application/cache/twitterstatus.[format]*, where "format" is either "xml" or "json", and writable by the web server. For first time use this file can be blank, it will be populated after your *cacheduration* time has elapsed
 - **cachefile** (provide custom cache file name to replace the default *twitterstatus.[format]* with *[cachefile].[format]*)
 - **cacheduration** (int, default = 5, only relevant if "usecache" is set): regenerate the local cache file if it is older than this value, in minutes
 - **createlinks** (true/false, default = true): whether or not to convert Twitter links embedded in tweets into clickable links
-- **numdays** (int, no default): only fetch tweets newer than this number of days
+- **numdays** (int, no default): only fetch tweets newer than this number of days.
 
 Usage Example
 -------------
 
 	<?php
 	$tweets = $this->twitterfetcher->getTweets(array(
-		'twitterID' => 'netmusicianorg',
-		'usecache' => false,
-		'count' => 0,
-		'numdays' => 30
+		'twitterID' 		=> 'netmusicianorg',
+		'ConsumerKey'		=> 'xvz1evFS4wEEPTGEFPHBog',
+		'ConsumerSecret'	=> 'L8qq9PZyRg6ieKGEKhZolGC0vJWLw8iEJ88DRdyOg',
+		'usecache' 			=> true,
+		'count' 			=> 0,
+		'numdays' 			=> 30
 	));
 	print_r($tweets);
 	?>
@@ -51,9 +55,18 @@ Usage Example
 
 In the above example, the variables "tweets" will be an array consisting of multiple tweets for when count is some value other than 1, or a single tweet object if it is set to 1. A non-standard property will be attached to the object called "elapsedtime" which is a human friendly elapsed time string in the format of "minutes/days/hours ago"
 
+Getting the api keys
+--------------------
+
+This spark requires the use of twitter api keys. To get these you need to sign up on the [twitter developer site](https://dev.twitter.com). Once you have signedin you need to create an new application. Under your twitter avatar there is an dropdown.  
+Name the application after it's inteneded use, the site name for example. After filling in the required fields you need should see the applications information page. On here the two keys you need are listed *Consumer key* and *Consumer secret*.  
+For this spark you do not need to change the access level or generate access tokens.
 
 Changelog
 ----------
+
+1.3.0
+- bug fix, Twitter has disabled API version 1.0. Version 1.1 requires authentication for most requests, please see the __getting the api keys__ section for how get the required keys
 
 1.2.1
 

--- a/libraries/twitterfetcher.php
+++ b/libraries/twitterfetcher.php
@@ -236,7 +236,7 @@ class twitterfetcher {
 
 	    if ( $configObj['usecache'] && file_exists($apiCacheFile) ) {
 	    	$code = json_decode( file_get_contents($apiCacheFile) );
-	    	$code = $code[$configObj['ConsumerKey']]; //Only use the token which belongs to this ConsumerKey
+	    	$code = $code->$configObj['ConsumerKey']; //Only use the token which belongs to this ConsumerKey
 	    } else {
 	        $basicToken = base64_encode( rawurlencode($configObj['ConsumerKey']) . ":" . rawurlencode($configObj['ConsumerSecret']) );
 	        

--- a/libraries/twitterfetcher.php
+++ b/libraries/twitterfetcher.php
@@ -23,6 +23,8 @@ class twitterfetcher {
 		}
 		if (!isset($configObj['usecache'])) {
 			$configObj['usecache'] = true;
+		} elseif ($configObj['usecache'] === false) {
+			log_message('info', 'TwitterFetcher: Cache should always be enabled unless you know what you are doing.');
 		}
 		if (!isset($configObj['cachefile'])) {
 			$configObj['cachefile'] = "";
@@ -112,10 +114,13 @@ class twitterfetcher {
 
 	function downloadTwitterStatus($configObj) {
 	// Load the rest client spark
-		$this->CI->load->spark('restclient/2.0.0');
+		$this->CI->load->spark('restclient/2.1.0');
 
 	// Run some setup
-		$this->CI->rest->initialize(array('server' => 'http://api.twitter.com/1/'));
+	$this->CI->rest->initialize(array('server' => 'https://api.twitter.com/1.1/'));
+
+	// Add the authorize token to the request
+	$this->CI->rest->http_header('Authorization: Bearer ' . $this->getAuthCode($configObj) );
 
 	// Pull in an array of tweets
 		if ($configObj['count']) {
@@ -222,7 +227,57 @@ class twitterfetcher {
 			return $elapsedtime['days'] . " day" . (($elapsedtime['days']>1) ? "s":"") . " ago";
 		}
 	}
-	
+	function getAuthCode($configObj){
+	    if ( !isset($configObj['ConsumerKey']) || !isset($configObj['ConsumerSecret']) ){
+	    	log_message('error', 'TwitterFetcher: You need to fill in both ConsumerKey AND ConsumerSecret in the config.');
+	        return false;
+	    }
+	    $apiCacheFile = APPPATH . "cache/TwitterFetcher_api.json";
+
+	    if ( $configObj['usecache'] && file_exists($apiCacheFile) ) {
+	    	$code = json_decode( file_get_contents($apiCacheFile) );
+	    	$code = $code[$configObj['ConsumerKey']]; //Only use the token which belongs to this ConsumerKey
+	    } else {
+	        $basicToken = base64_encode( rawurlencode($configObj['ConsumerKey']) . ":" . rawurlencode($configObj['ConsumerSecret']) );
+	        
+	        $ch = curl_init();
+	        
+	        //header as required by twitter
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+            'Content-Type: application/x-www-form-urlencoded;charset=UTF-8',
+            'Authorization: Basic ' . $basicToken
+            ));
+     
+            curl_setopt($ch, CURLOPT_URL, 'https://api.twitter.com/oauth2/token');
+            curl_setopt($ch, CURLOPT_USERAGENT, "TwitterFetcher-CodeIgniter-Spark");
+            curl_setopt($ch,CURLOPT_POST, 1);
+            curl_setopt($ch,CURLOPT_POSTFIELDS, 'grant_type=client_credentials');
+            curl_setopt($ch, CURLOPT_HEADER, 0);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 10); //in seconds
+            $output = json_decode( curl_exec($ch) );
+            curl_close($ch);
+            
+            if ( !isset($output->errors) ){
+                $code = $output->access_token;
+            } else {
+            	log_message('error', 'TwitterFetcher: Couldn\'t fetch token: "' . $output->errors . '"');
+            	return false;
+            }
+           	if ( $configObj['usecache'] && is_writable(APPPATH . "cache") ){
+				if ( file_exists($apiCacheFile) ) {
+					$codeCache = file_get_contents($apiCacheFile);
+					$codeCache = json_decode($codeCache);
+				} else {
+					$codeCache = array();
+				}
+				$codeCache[$configObj['ConsumerKey']] = $code;
+				file_put_contents($apiCacheFile, json_encode($codeCache));
+			}
+        }
+        
+        return $code;
+	}
 
 }
 

--- a/spark.info
+++ b/spark.info
@@ -2,7 +2,7 @@ name: twitterfetcher
 
 # This is the current version of this spark. All sparks should be in
 #  x.x.x format. Validation will fail otherwise.
-version: 1.2.1
+version: 1.3.0
 
 # This is the version of CodeIgniter this spark is compatible up to. It should
 #  be in x.x.x format
@@ -10,5 +10,5 @@ compatibility: 2.1.2
 
 # There are no dependencies now, but when there are, uncomment below.
 dependencies:
-   curl: 1.2.0
-   restclient: 2.0.0
+   curl: 1.2.1
+   restclient: 2.1.0


### PR DESCRIPTION
API 1.0 has been deprecated for a while and has been terminated on jun 11 2013. 
This spark no longer works due to this.

https://dev.twitter.com/blog/api-v1-is-retired

A possible solution is application only authentication:
https://dev.twitter.com/docs/auth/application-only-auth
